### PR TITLE
Make setup.py use nosetests.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
         " with both Tournament Words List and SOWPODS."
     ),
     download_url='https://github.com/a-tal/nagaram',
+    tests_require=['nose'],
+    test_suite='nose.collector',
     license="BSD",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I'm developing an automated test system for packages uploaded to PyPI, and I noticed that your package had tests that weren't being picked up because they were just defined in `.travis.yml`, not in `setup.py test`.

This patch enables you to run the tests with `setup.py test`. Your existing testing infrastruct is unchanged.
